### PR TITLE
expand tilde for home directory

### DIFF
--- a/plugins/50-fuzzy-tools/plugins/60-fuzzy-yank/yankring/vimrc.plugins
+++ b/plugins/50-fuzzy-tools/plugins/60-fuzzy-yank/yankring/vimrc.plugins
@@ -4,7 +4,7 @@ let g:yankring_replace_n_pkey = '<leader>['
 let g:yankring_replace_n_nkey = '<leader>]'
 
 " put the yankring_history file in ~/.backup
-let g:yankring_history_dir = '~/.backup'
+let g:yankring_history_dir = expand('~/.backup')
 
 let g:yankring_max_history = 1000
 


### PR DESCRIPTION
Otherwise vim would try to open literally `~/.backup/yankring_...` and fail with error:

Error detected while processing function <SNR>103_YRInit..<SNR>103_YRHistoryRead..<SNR>103_YRHistorySave:
line   13:
E482: Can't create file ~/.backup/yankring_history_v2.txt
YRHistorySave: Unable to save yankring history file: ~/.backup/yankring_history_v2.txt