### PR TITLE
Fix vim-scripts.org is deprecated warning

### DIFF
--- a/plugins/30-general/plugins/greplace/files/vimrc.plugins
+++ b/plugins/30-general/plugins/greplace/files/vimrc.plugins
@@ -1,1 +1,1 @@
-call dein#add('greplace.vim')
+call dein#add('vim-scripts/greplace.vim')

--- a/plugins/30-general/plugins/utl/files/vimrc.plugins
+++ b/plugins/30-general/plugins/utl/files/vimrc.plugins
@@ -1,4 +1,4 @@
-call dein#add('utl.vim')
+call dein#add('vim-scripts/utl.vim')
 
 " config help: <url:~/.vim/dein/.dein/plugin/utl_rc.vim#r=utl_cfg_hdl_scm_http>
 if has("mac")

--- a/plugins/50-fuzzy-tools/plugins/60-fuzzy-yank/yankring/vimrc.plugins
+++ b/plugins/50-fuzzy-tools/plugins/60-fuzzy-yank/yankring/vimrc.plugins
@@ -1,4 +1,4 @@
-call dein#add('YankRing.vim')
+call dein#add('vim-scripts/YankRing.vim')
 
 let g:yankring_replace_n_pkey = '<leader>['
 let g:yankring_replace_n_nkey = '<leader>]'

--- a/plugins/60-development/plugins/fugitive/files/vimrc.plugins
+++ b/plugins/60-development/plugins/fugitive/files/vimrc.plugins
@@ -1,5 +1,5 @@
 call dein#add('tpope/vim-fugitive')
-call dein#add('Merginal')
+call dein#add('vim-scripts/Merginal')
 
 " ,g for Ggrep
 nmap <leader>g :silent Ggrep<space>

--- a/plugins/70-languages/plugins/ruby/plugins/9-rails/files/vimrc.plugins
+++ b/plugins/70-languages/plugins/ruby/plugins/9-rails/files/vimrc.plugins
@@ -2,7 +2,7 @@
 call dein#add('tpope/vim-rails')
 
 " apidock.com docs integration
-call dein#add('apidock.vim')
+call dein#add('vim-scripts/apidock.vim')
 
 " lightweight Rspec runner for Vim
 call dein#add('thoughtbot/vim-rspec')


### PR DESCRIPTION
Implicit call to vim-scripts is deprecated as can be seen here:
https://github.com/Shougo/dein.vim/blob/master/autoload/dein/types/git.vim#L90

This commit should fix those warnings.